### PR TITLE
faet: 관리자 회원가입/로그인 기능 구현

### DIFF
--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/controller/AdminController.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/controller/AdminController.java
@@ -1,6 +1,8 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.controller;
 
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SigninAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SignupAdminRequest;
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.SigninAdminResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.SignupAdminResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRoleRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRequest;
@@ -10,6 +12,7 @@ import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateA
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateAdminRoleResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateAdminStatusResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.service.AdminService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,6 +31,21 @@ public class AdminController {
     public ResponseEntity<SignupAdminResponse> signup(@Valid @RequestBody SignupAdminRequest request) {
         SignupAdminResponse response = adminService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 관리자 로그인 요청 API
+    @PostMapping("/signin")
+    public ResponseEntity<SigninAdminResponse> signin(
+            @Valid @RequestBody SigninAdminRequest request, HttpSession session
+    ) {
+        return ResponseEntity.ok(adminService.signin(request, session));
+    }
+
+    // 관리자 로그아웃 요청 API
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpSession session) {
+        adminService.logout(session);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{adminId}")

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/SessionAdmin.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/SessionAdmin.java
@@ -1,0 +1,25 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.dto;
+
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.AdminRole;
+import lombok.Getter;
+
+@Getter
+public class SessionAdmin {
+
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final AdminRole role;
+
+    public SessionAdmin(Long id, String name,String email, AdminRole role) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public static SessionAdmin from(Admin admin) {
+        return new SessionAdmin(admin.getId(), admin.getName(), admin.getEmail(), admin.getRole());
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/request/SigninAdminRequest.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/request/SigninAdminRequest.java
@@ -1,0 +1,18 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SigninAdminRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/response/SigninAdminResponse.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/dto/response/SigninAdminResponse.java
@@ -1,0 +1,39 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.dto.response;
+
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.AdminRole;
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.AdminStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SigninAdminResponse {
+
+    private final Long id;
+    private final String name;
+    private final String email;
+    private final AdminRole role;
+    private final AdminStatus status;
+    private final LocalDateTime createdAt;
+
+    public SigninAdminResponse(Long id, String name, String email, AdminRole role, AdminStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static SigninAdminResponse from(Admin admin) {
+        return new SigninAdminResponse(
+                admin.getId(),
+                admin.getName(),
+                admin.getEmail(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/Admin.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/Admin.java
@@ -3,6 +3,7 @@ package com.spartabugkiller.ecommercebackofficeproject.admin.entity;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRoleRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminStatusRequest;
+import com.spartabugkiller.ecommercebackofficeproject.admin.exception.AdminInactiveException;
 import com.spartabugkiller.ecommercebackofficeproject.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.Valid;
@@ -38,6 +39,7 @@ public class Admin extends BaseEntity {
     private LocalDateTime approvedAt;
     private LocalDateTime rejectedAt;
     private String rejectedReason;
+    private LocalDateTime deletedAt;
 
     // 신규 관리자 생성 (무조건 PENDING)
     public Admin(String name, String email, String password, String phoneNumber, AdminRole role) {
@@ -49,23 +51,31 @@ public class Admin extends BaseEntity {
         this.status = AdminStatus.PENDING;
     }
 
-    // 승인 처리
+    // 승인 처리 (APPROVED)
     public void approve(Long superAdminId) {
         this.status = AdminStatus.APPROVED;
         this.approvedBy = superAdminId;
         this.approvedAt = LocalDateTime.now();
     }
 
-    // 거절 처리
+    // 거절 처리 (REJECTED)
     public void reject(String reason) {
         this.status = AdminStatus.REJECTED;
         this.rejectedAt = LocalDateTime.now();
         this.rejectedReason = reason;
     }
 
-    // 계정 비활성화 (Soft Delete)
+    // 계정 비활성화 (INACTIVE)
     public void deactivate() {
-        delete();
+        if (this.deletedAt != null) {
+            throw new AdminInactiveException();
+        }
+        this.status = AdminStatus.INACTIVE;
+    }
+
+    // Soft Delete
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void updateInfo(UpdateAdminRequest request) {

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/AdminStatus.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/AdminStatus.java
@@ -2,5 +2,5 @@ package com.spartabugkiller.ecommercebackofficeproject.admin.entity;
 
 public enum AdminStatus {
 
-    PENDING, APPROVED, REJECTED, BLOCKED
+    PENDING, APPROVED, REJECTED, BLOCKED, INACTIVE
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminBlockedException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminBlockedException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminBlockedException extends ServiceException {
+
+    public AdminBlockedException() {
+        super(HttpStatus.LOCKED, "정지된 계정입니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminEmailAlreadyExistsException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminEmailAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminEmailAlreadyExistsException extends ServiceException {
+
+    public AdminEmailAlreadyExistsException() {
+        super(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInactiveException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInactiveException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminInactiveException extends ServiceException {
+
+    public AdminInactiveException() {
+        super(HttpStatus.FORBIDDEN, "비활성화된 관리자 계정입니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidEmailException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidEmailException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminInvalidEmailException extends ServiceException {
+
+    public AdminInvalidEmailException() {
+        super(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidPasswordException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidPasswordException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminInvalidPasswordException extends ServiceException {
+
+    public AdminInvalidPasswordException() {
+        super(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminPendingException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminPendingException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminPendingException extends ServiceException {
+
+    public AdminPendingException() {
+        super(HttpStatus.FORBIDDEN, "승인 대기 중인 계정입니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminRejectedException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminRejectedException.java
@@ -1,0 +1,11 @@
+package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+import org.springframework.http.HttpStatus;
+
+public class AdminRejectedException extends ServiceException {
+
+    public AdminRejectedException() {
+        super(HttpStatus.FORBIDDEN, "승인이 거절된 계정입니다.");
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/repository/AdminRepository.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/repository/AdminRepository.java
@@ -3,6 +3,11 @@ package com.spartabugkiller.ecommercebackofficeproject.admin.repository;
 import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+    // 이메일을 가진 Admin이 DB에 존재하는지 (회원가입 중복 체크)
     boolean existsByEmail(String email);
+    // 이메일로 Admin 한 명을 찾아서 가져온다 (로그인, 상태검사, 계정조회)
+    Optional<Admin> findByEmail(String email);
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/service/AdminService.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/service/AdminService.java
@@ -1,19 +1,21 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.service;
 
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SigninAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SignupAdminRequest;
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.SigninAdminResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.SignupAdminResponse;
-import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminRoleRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.UpdateAdminStatusRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.GetAdminDetailResponse;
-import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateAdminResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateAdminRoleResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.UpdateAdminStatusResponse;
 import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
-import com.spartabugkiller.ecommercebackofficeproject.admin.exception.AdminNotFoundException;
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.AdminStatus;
+import com.spartabugkiller.ecommercebackofficeproject.admin.exception.*;
 import com.spartabugkiller.ecommercebackofficeproject.admin.repository.AdminRepository;
 import com.spartabugkiller.ecommercebackofficeproject.global.config.PasswordEncoder;
-import com.spartabugkiller.ecommercebackofficeproject.global.exception.AdminEmailAlreadyExistsException;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.*;
+import jakarta.servlet.http.HttpSession;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import org.springframework.transaction.annotation.Transactional;
 import jakarta.validation.Valid;
@@ -55,20 +57,66 @@ public class AdminService {
         return SignupAdminResponse.from(saved);
     }
 
+    // 로그인 로직
+    @Transactional(readOnly = true)
+    public SigninAdminResponse signin(SigninAdminRequest request, HttpSession session) {
+
+        // 이메일 검증
+        Admin admin = adminRepository.findByEmail(request.getEmail())
+                .orElseThrow(AdminInvalidEmailException::new);
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), admin.getPassword())) {
+            throw new AdminInvalidPasswordException();
+        }
+
+        // 탈퇴 여부 먼저 확인 (존재 자체가 없음)
+        if (admin.getDeletedAt() != null) {
+            throw new AdminInactiveException();
+        }
+
+        // 승인 대기 상태
+        if (admin.getStatus() == AdminStatus.PENDING) {
+            throw new AdminPendingException();
+        }
+
+        // 승인 거절 상태
+        if (admin.getStatus() == AdminStatus.REJECTED) {
+            throw new AdminRejectedException();
+        }
+
+        // 계정 정지 상태
+        if (admin.getStatus() == AdminStatus.BLOCKED) {
+            throw new AdminBlockedException();
+        }
+
+        // 계정 비활성화 상태
+        if (admin.getStatus() == AdminStatus.INACTIVE) {
+            throw new AdminInactiveException();
+        }
+
+        // 승인 처리 시 Response DTO로 변환해서 반환
+        return new SigninAdminResponse(
+                admin.getId(),
+                admin.getName(),
+                admin.getEmail(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getCreatedAt()
+        );
+    }
+
+    // 로그아웃 로직
+    @Transactional
+    public void logout(HttpSession session) {
+        session.invalidate();
+    }
+
     @Transactional(readOnly = true)
     public GetAdminDetailResponse getAdmin(Long adminId) {
         // session 유저의 권환 학인 후 찾는다
         Admin admin = findById(adminId);
         return GetAdminDetailResponse.from(admin);
-    }
-
-    @Transactional
-    public UpdateAdminResponse updateInfo(UpdateAdminRequest request, Long adminId) {
-        // session 유저의 권한 확인 후 업데이트
-
-        Admin admin = findById(adminId);
-        admin.updateInfo(request);
-        return UpdateAdminResponse.from(admin);
     }
 
     @Transactional

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/AdminEmailAlreadyExistsException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/AdminEmailAlreadyExistsException.java
@@ -1,7 +1,0 @@
-package com.spartabugkiller.ecommercebackofficeproject.global.exception;
-
-public class AdminEmailAlreadyExistsException extends RuntimeException {
-    public AdminEmailAlreadyExistsException() {
-        super("이미 사용 중인 이메일입니다.");
-    }
-}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/GlobalExceptionHandler.java
@@ -28,11 +28,4 @@ public class GlobalExceptionHandler {
         ExceptionResponse response = ExceptionResponse.from(exception.getStatusCode().value(), errorMessage, request.getRequestURI());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
-
-    @ExceptionHandler(AdminEmailAlreadyExistsException.class)
-    public ResponseEntity<String> handleAdminEmailAlreadyExists(AdminEmailAlreadyExistsException e) {
-        return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(e.getMessage());
-    }
 }


### PR DESCRIPTION
## 📒 Issue Number
closed #25 

## 📒 Description
관리자 회원가입/로그인 API 기능을 구현했습니다.

- 관리자 회원가입 기능 구현
- 관리자 로그인 기능 구현
- 비밀번호 암호화 처리
- 관리자 상태(PENDING / APPROVED / REJECTED / INACTIVE)에 따른 접근 제어 로직 추가
- 커스텀 예외 클래스 및 전역 예외 처리 구조 적용

## 📒 Test Result
### 관리자 회원가입
- 정상 회원가입 성공 확인
<img width="1917" height="1353" alt="image" src="https://github.com/user-attachments/assets/3b62718d-95f7-46f7-92e4-72b7647f8a4a" />

### 관리자 로그인
- 승인된 관리자 로그인 성공
<img width="1916" height="1396" alt="image" src="https://github.com/user-attachments/assets/34ac503a-03d4-46a8-9c1f-58cd546eb1df" />

- 승인된 관리자 로그아웃 성공
<img width="1919" height="1360" alt="image" src="https://github.com/user-attachments/assets/45fc7284-855e-4b0b-84ff-e3ebaa32959a" />

## 📒 To Reviewer
