### PR TITLE
fix: 관리자 회원가입/로그인 예외 코드 및 엔티티 수정

### DIFF
--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/controller/AdminController.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.controller;
 
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.SessionAdmin;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SigninAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.SignupAdminRequest;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.SigninAdminResponse;

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/Admin.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/entity/Admin.java
@@ -67,15 +67,10 @@ public class Admin extends BaseEntity {
 
     // 계정 비활성화 (INACTIVE)
     public void deactivate() {
-        if (this.deletedAt != null) {
+        if (getDeletedAt() != null) {
             throw new AdminInactiveException();
         }
         this.status = AdminStatus.INACTIVE;
-    }
-
-    // Soft Delete
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
     }
 
     public void updateInfo(UpdateAdminRequest request) {

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminBlockedException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminBlockedException.java
@@ -1,11 +1,10 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminBlockedException extends ServiceException {
-
     public AdminBlockedException() {
-        super(HttpStatus.LOCKED, "정지된 계정입니다.");
+        super(ErrorCode.ADMIN_BLOCKED.getStatus(), ErrorCode.ADMIN_BLOCKED.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminEmailAlreadyExistsException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminEmailAlreadyExistsException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminEmailAlreadyExistsException extends ServiceException {
 
     public AdminEmailAlreadyExistsException() {
-        super(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+        super(ErrorCode.ADMIN_EMAIL_DUPLICATED.getStatus(), ErrorCode.ADMIN_EMAIL_DUPLICATED.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInactiveException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInactiveException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminInactiveException extends ServiceException {
 
     public AdminInactiveException() {
-        super(HttpStatus.FORBIDDEN, "비활성화된 관리자 계정입니다.");
+        super( ErrorCode.ADMIN_INACTIVE.getStatus(), ErrorCode.ADMIN_INACTIVE.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidEmailException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidEmailException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminInvalidEmailException extends ServiceException {
 
     public AdminInvalidEmailException() {
-        super(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다.");
+        super( ErrorCode.ADMIN_INVALID_EMAIL.getStatus(), ErrorCode.ADMIN_INVALID_EMAIL.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidPasswordException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminInvalidPasswordException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminInvalidPasswordException extends ServiceException {
 
     public AdminInvalidPasswordException() {
-        super(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
+        super( ErrorCode.ADMIN_INVALID_PASSWORD.getStatus(), ErrorCode.ADMIN_INVALID_PASSWORD.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminPendingException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminPendingException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminPendingException extends ServiceException {
 
     public AdminPendingException() {
-        super(HttpStatus.FORBIDDEN, "승인 대기 중인 계정입니다.");
+        super( ErrorCode.ADMIN_PENDING.getStatus(), ErrorCode.ADMIN_PENDING.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminRejectedException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/exception/AdminRejectedException.java
@@ -1,11 +1,11 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.exception;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
-import org.springframework.http.HttpStatus;
 
 public class AdminRejectedException extends ServiceException {
 
     public AdminRejectedException() {
-        super(HttpStatus.FORBIDDEN, "승인이 거절된 계정입니다.");
+        super( ErrorCode.ADMIN_REJECTED.getStatus(), ErrorCode.ADMIN_REJECTED.getMessage());
     }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/service/AdminService.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.spartabugkiller.ecommercebackofficeproject.admin.service;
 
+import com.spartabugkiller.ecommercebackofficeproject.admin.dto.SessionAdmin;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.request.*;
 import com.spartabugkiller.ecommercebackofficeproject.admin.dto.response.*;
 import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
@@ -11,7 +12,6 @@ import com.spartabugkiller.ecommercebackofficeproject.global.exception.*;
 import jakarta.servlet.http.HttpSession;
 import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
 import org.springframework.transaction.annotation.Transactional;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -87,6 +87,9 @@ public class AdminService {
         if (admin.getStatus() == AdminStatus.INACTIVE) {
             throw new AdminInactiveException();
         }
+
+        // 세션에 로그인 정보 저장
+        session.setAttribute("LOGIN_ADMIN", SessionAdmin.from(admin));
 
         // 승인 처리 시 Response DTO로 변환해서 반환
         return new SigninAdminResponse(

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/ErrorCode.java
@@ -8,8 +8,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // amin exception
-    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 관리자를 찾을 수 없습니다."),
+    ADMIN_BLOCKED(HttpStatus.LOCKED, "정지된 계정입니다."),
+    ADMIN_PENDING(HttpStatus.FORBIDDEN, "승인 대기 중인 계정입니다."),
+    ADMIN_REJECTED(HttpStatus.FORBIDDEN, "승인이 거절된 계정입니다."),
+    ADMIN_INACTIVE(HttpStatus.FORBIDDEN, "비활성화된 계정입니다."),
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자를 찾을 수 없습니다."),
+    ADMIN_INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    ADMIN_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    ADMIN_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 
     // product exception
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다.");


### PR DESCRIPTION
## 📒 Issue Number
closed #25 

## 📒 Description
관리자 로그인/세션 흐름 리팩토링 과정에서 발생한 예외 코드 및 Admin 엔티티 구조를 수정했습니다.
- 관리자 상태에 따른 커스텀 예외 클래스를 정리하여, 비정상 상태 계정 접근 시 명확한 메시지와 HTTP Status 코드가 반환되도록 개선했습니다.
- Admin 엔티티의 상태 처리 로직을 정리하여 비활성화/탈퇴 상태 검증이 한 곳에서 관리되도록 리팩토링했습니다.

## 📒 Test Result
- 승인 대기(PENDING) 상태 계정으로 로그인 시  403 에러가 정상적으로 반환되는 것을 확인했습니다.
<img width="1916" height="1420" alt="image" src="https://github.com/user-attachments/assets/2be200d1-1f3b-435a-8ae3-41cbf06df1e6" />

- 승인 거절(REJECTED) 상태 계정으로 로그인 시  403 에러가 정상적으로 반환되는 것을 확인했습니다.
<img width="1921" height="1355" alt="image" src="https://github.com/user-attachments/assets/1900438c-8316-4364-b1ab-b2dcfde75fd2" />

- 계정 정지(BLOCKED) 상태 계정으로 로그인 시  403 에러가 정상적으로 반환되는 것을 확인했습니다.
<img width="1913" height="1361" alt="image" src="https://github.com/user-attachments/assets/67a80169-c64f-4fb1-94af-fe29d6828d38" />

- 비활성(INACTIVE) 상태 계정으로 로그인 시  403 에러가 정상적으로 반환되는 것을 확인했습니다.
<img width="1917" height="1357" alt="image" src="https://github.com/user-attachments/assets/ed7cb05e-1f64-4abf-94d4-86b3bf149a9d" />

## 📒 To Reviewer