### PR TITLE
feat: CS 주문 생성

### DIFF
--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/global/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // admin exception
     ADMIN_BLOCKED(HttpStatus.LOCKED, "정지된 계정입니다."),
     ADMIN_PENDING(HttpStatus.FORBIDDEN, "승인 대기 중인 계정입니다."),
     ADMIN_REJECTED(HttpStatus.FORBIDDEN, "승인이 거절된 계정입니다."),
@@ -19,18 +20,23 @@ public enum ErrorCode {
     REJECTED_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "거부 사유는 필수 입력값입니다."),
     NOT_SUPER_ADMIN(HttpStatus.UNAUTHORIZED, "권한이 없는 관리자입니다."),
 
-    // product exception,
+    // product exception
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
     PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "단종된 상품은 재고를 변경할 수 없습니다."),
-
     INVALID_PRODUCT_NAME(HttpStatus.BAD_REQUEST, "상품명은 비어 있을 수 없습니다."),
     INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "가격은 0 이상이어야 합니다."),
     INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리는 필수입니다."),
 
     // global exception
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "관리자 로그인이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "슈퍼 관리자 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "슈퍼 관리자 권한이 없습니다."),
+
+    // order exception
+    ORDER_CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 고객입니다."),
+    ORDER_PRODUCT_DISCONTINUED(HttpStatus.BAD_REQUEST, "단종된 상품은 주문할 수 없습니다."),
+    ORDER_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족하여 주문이 불가능합니다."),
+    ORDER_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "주문 수량은 1개 이상이어야 합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/controller/OrderController.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/controller/OrderController.java
@@ -1,4 +1,37 @@
 package com.spartabugkiller.ecommercebackofficeproject.order.controller;
 
+import com.spartabugkiller.ecommercebackofficeproject.global.common.SessionUtils;
+import com.spartabugkiller.ecommercebackofficeproject.order.dto.request.OrderCreateRequest;
+import com.spartabugkiller.ecommercebackofficeproject.order.dto.response.OrderCreateResponse;
+import com.spartabugkiller.ecommercebackofficeproject.order.service.OrderService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admins")
+@RequiredArgsConstructor
 public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     *  주문 생성
+     */
+    @PostMapping("/orders")
+    public ResponseEntity<OrderCreateResponse> createOrder(
+            @Valid @RequestBody OrderCreateRequest request,
+            HttpSession session) {
+
+        Long adminId = SessionUtils.getLoginAdmin(session).getId();
+
+        OrderCreateResponse response = orderService.createOrder(request, adminId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/dto/request/OrderCreateRequest.java
@@ -1,4 +1,27 @@
 package com.spartabugkiller.ecommercebackofficeproject.order.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class OrderCreateRequest {
+
+    @NotNull(message = "고객 ID는 필수입니다.")
+    private Long customerId;
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+    private Integer quantity;
+
+    public OrderCreateRequest(Long customerId, Long productId, Integer quantity) {
+        this.customerId = customerId;
+        this.productId = productId;
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/dto/response/OrderCreateResponse.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/dto/response/OrderCreateResponse.java
@@ -1,4 +1,33 @@
 package com.spartabugkiller.ecommercebackofficeproject.order.dto.response;
 
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.Order;
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.OrderStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class OrderCreateResponse {
+
+    private final Long id;
+    private final String orderNum;
+    private final String customerName;
+    private final String productName;
+    private final int quantity;
+    private final int totalPrice;
+    private final OrderStatus status;
+    private final String adminName;
+    private final LocalDateTime createdAt;
+
+    public OrderCreateResponse(Order order) {
+        this.id = order.getId();
+        this.orderNum = order.getOrderNum();
+        this.customerName = order.getCustomer().getUsername();
+        this.productName = order.getProduct().getName();
+        this.quantity = order.getQuantity();
+        this.totalPrice = order.getTotalPrice();
+        this.status = order.getStatus();
+        this.adminName = order.getAdmin() != null ? order.getAdmin().getName() : "고객 직접 주문";
+        this.createdAt = order.getCreatedAt();
+    }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/Order.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/Order.java
@@ -5,10 +5,12 @@ import com.spartabugkiller.ecommercebackofficeproject.customer.entity.Customer;
 import com.spartabugkiller.ecommercebackofficeproject.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -16,12 +18,14 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Order {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 주문번호 예시 : 20260116-001
     @Column(nullable = false, unique = true, length = 50)
     private String orderNum;
 
@@ -61,7 +65,15 @@ public class Order {
     @JoinColumn(name = "admin_id")
     private Admin admin;
 
-
-
-
+    @Builder
+    public Order(String orderNum, OrderStatus status, int totalPrice, int quantity,
+                 Customer customer, Product product, Admin admin) {
+        this.orderNum = orderNum;
+        this.status = status;
+        this.totalPrice = totalPrice;
+        this.quantity = quantity;
+        this.customer = customer;
+        this.product = product;
+        this.admin = admin;
+    }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/OrderDailySequence.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/OrderDailySequence.java
@@ -1,0 +1,32 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_daily_sequence")
+@Getter
+@NoArgsConstructor
+public class OrderDailySequence {
+
+    @Id
+    @Column(name = "order_date", length = 8)
+    private String orderDate;
+
+    @Column(nullable = false)
+    private int seq;
+
+    public OrderDailySequence(String orderDate) {
+        this.orderDate = orderDate;
+        this.seq = 0;
+    }
+
+    public int nextSeq() {
+        this.seq++;
+        return this.seq;
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/OrderStatus.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/entity/OrderStatus.java
@@ -4,10 +4,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum OrderStatus {
-    READY,
-    SHIPPING,
-    COMPLETED,
-    CANCELED
+    READY("상품준비중"),
+    SHIPPING("배송중"),
+    COMPLETED("배송완료"),
+    CANCELED("주문취소");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderCustomerNotFoundException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderCustomerNotFoundException.java
@@ -1,0 +1,10 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+
+public class OrderCustomerNotFoundException extends ServiceException {
+    public OrderCustomerNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getStatus(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderOutOfStockException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderOutOfStockException.java
@@ -1,0 +1,10 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+
+public class OrderOutOfStockException extends ServiceException {
+    public OrderOutOfStockException(ErrorCode errorCode) {
+        super(errorCode.getStatus(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderProductDiscontinuedException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderProductDiscontinuedException.java
@@ -1,0 +1,10 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+
+public class OrderProductDiscontinuedException extends ServiceException {
+    public OrderProductDiscontinuedException(ErrorCode errorCode) {
+        super(errorCode.getStatus(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderQuantityInvalidException.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/exception/OrderQuantityInvalidException.java
@@ -1,0 +1,10 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.exception;
+
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ServiceException;
+
+public class OrderQuantityInvalidException extends ServiceException {
+    public OrderQuantityInvalidException(ErrorCode errorCode) {
+        super(errorCode.getStatus(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/repository/OrderDailySequenceRepository.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/repository/OrderDailySequenceRepository.java
@@ -1,0 +1,20 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.repository;
+
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.OrderDailySequence;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OrderDailySequenceRepository
+        extends JpaRepository<OrderDailySequence, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from OrderDailySequence s where s.orderDate = :date")
+    Optional<OrderDailySequence> findByDateForUpdate(
+            @Param("date") String date
+    );
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/service/OrderNumberGenerator.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/service/OrderNumberGenerator.java
@@ -1,0 +1,33 @@
+package com.spartabugkiller.ecommercebackofficeproject.order.service;
+
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.OrderDailySequence;
+import com.spartabugkiller.ecommercebackofficeproject.order.repository.OrderDailySequenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class OrderNumberGenerator {
+
+    private final OrderDailySequenceRepository sequenceRepository;
+
+    @Transactional
+    public String generate() {
+
+        String today = LocalDate.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        OrderDailySequence sequence = sequenceRepository
+                .findByDateForUpdate(today)
+                .orElseGet(() -> new OrderDailySequence(today));
+
+        int nextSeq = sequence.nextSeq();
+        sequenceRepository.save(sequence);
+
+        return today + "-" + String.format("%03d", nextSeq);
+    }
+}

--- a/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/service/OrderService.java
+++ b/src/main/java/com/spartabugkiller/ecommercebackofficeproject/order/service/OrderService.java
@@ -1,4 +1,94 @@
 package com.spartabugkiller.ecommercebackofficeproject.order.service;
 
+import com.spartabugkiller.ecommercebackofficeproject.admin.entity.Admin;
+import com.spartabugkiller.ecommercebackofficeproject.admin.exception.AdminNotFoundException;
+import com.spartabugkiller.ecommercebackofficeproject.admin.repository.AdminRepository;
+import com.spartabugkiller.ecommercebackofficeproject.customer.entity.Customer;
+import com.spartabugkiller.ecommercebackofficeproject.customer.repository.CustomerRepository;
+import com.spartabugkiller.ecommercebackofficeproject.global.exception.ErrorCode;
+import com.spartabugkiller.ecommercebackofficeproject.order.dto.request.OrderCreateRequest;
+import com.spartabugkiller.ecommercebackofficeproject.order.dto.response.OrderCreateResponse;
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.Order;
+import com.spartabugkiller.ecommercebackofficeproject.order.entity.OrderStatus;
+import com.spartabugkiller.ecommercebackofficeproject.order.exception.OrderCustomerNotFoundException;
+import com.spartabugkiller.ecommercebackofficeproject.order.exception.OrderOutOfStockException;
+import com.spartabugkiller.ecommercebackofficeproject.order.exception.OrderProductDiscontinuedException;
+import com.spartabugkiller.ecommercebackofficeproject.order.exception.OrderQuantityInvalidException;
+import com.spartabugkiller.ecommercebackofficeproject.order.repository.OrderRepository;
+import com.spartabugkiller.ecommercebackofficeproject.product.entity.Product;
+import com.spartabugkiller.ecommercebackofficeproject.product.entity.ProductStatus;
+import com.spartabugkiller.ecommercebackofficeproject.product.exception.ProductNotFoundException;
+import com.spartabugkiller.ecommercebackofficeproject.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
 public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final CustomerRepository customerRepository;
+    private final ProductRepository productRepository;
+    private final AdminRepository adminRepository;
+    private final OrderNumberGenerator orderNumberGenerator;
+
+    @Transactional
+    public OrderCreateResponse createOrder(OrderCreateRequest request, Long adminId) {
+        Admin loginAdmin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new AdminNotFoundException(ErrorCode.ADMIN_NOT_FOUND));
+
+        Customer customer = customerRepository.findById(request.getCustomerId())
+                .orElseThrow(() -> new OrderCustomerNotFoundException(ErrorCode.ORDER_CUSTOMER_NOT_FOUND));
+
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new ProductNotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 단종,품절,재고부족 검증
+        validationProductForOrder(product, request.getQuantity());
+
+        // 재고 차감, 상태 변경
+        product.updateStock(product.getStock() - request.getQuantity());
+
+        // 주문 번호
+        String orderNum = orderNumberGenerator.generate();
+
+        Order order = Order.builder()
+                .orderNum(orderNum)
+                .status(OrderStatus.READY)
+                .quantity(request.getQuantity())
+                .totalPrice(product.getPrice() * request.getQuantity())
+                .customer(customer)
+                .product(product)
+                .admin(loginAdmin)
+                .build();
+
+        Order savedOrder = orderRepository.save(order);
+
+        return new OrderCreateResponse(savedOrder);
+    }
+
+    private void validationProductForOrder(Product product, int quantity) {
+        // 단종 상태 확인
+        if (product.getStatus() == ProductStatus.DISCONTINUED) {
+            throw new OrderProductDiscontinuedException(ErrorCode.ORDER_PRODUCT_DISCONTINUED);
+        }
+
+        // 수량 1 이상 검증
+        if (quantity < 1) {
+            throw new OrderQuantityInvalidException(ErrorCode.ORDER_QUANTITY_INVALID);
+        }
+
+        // 품절 상태 확인
+        if (product.getStatus() == ProductStatus.OUT_OF_STOCK) {
+            throw new OrderOutOfStockException(ErrorCode.ORDER_OUT_OF_STOCK);
+        }
+
+        // 재고 부족 확인
+        if (product.getStock() < quantity) {
+            throw new OrderOutOfStockException(ErrorCode.ORDER_OUT_OF_STOCK);
+        }
+    }
 }


### PR DESCRIPTION
## 📒 Issue Number
closed #64 

## 📒 Description
주문 등록 요청 시 다음 정보를 입력받습니다.
- 고객 정보
- 상품 정보
- 수량

서버에서 처리합니다.

- 주문일 자동 생성
- 주문번호 자동 생성
- 초기 상태 설정: `준비중`
- 주문 총 금액 계산: `상품 가격 × 수량` (주문 당시 상품 가격 기준)
- 주문 수량만큼 상품 재고 검증 및 차감 처리
- 재고 변경에 따른 상품 상태 자동 전환 처리
- 주문 등록 관리자 정보 저장 (로그인 유저 == 주문 등록 관리자)
    CS 대리 주문의 경우, 주문 소유자(고객)와 별도로 주문 등록 관리자 정보를 저장합니다.

`예외 상황`
- 수량은 1 이상이어야 합니다.
- 상품이 `단종` 상태인 경우 주문 생성이 불가합니다.
- 상품이 `품절` 상태인 경우 주문 생성이 불가합니다.
- 재고가 주문 수량보다 부족한 경우 주문 생성이 불가합니다.

## 📒 Test Result
주문 등록 성공
<img width="964" height="633" alt="주문 등록" src="https://github.com/user-attachments/assets/38b5ba7d-f8ed-41fd-a4b3-5b87875da6c9" />

주문 등록 로그인 필요
<img width="960" height="568" alt="주문 등록 로그인 필요" src="https://github.com/user-attachments/assets/233ba92d-2a73-472c-8698-28b3f2510349" />

주문 등록 수량 1 미만
<img width="965" height="542" alt="주문 등록 수량 1 미만" src="https://github.com/user-attachments/assets/da81924e-7914-4462-8276-65138571466a" />

주문 등록 단종 상태
<img width="954" height="568" alt="주문 등록 단종 상태" src="https://github.com/user-attachments/assets/e1c42eba-4c6b-42c9-b21a-a4cf53771d27" />

주문 등록 품절 상태
<img width="955" height="544" alt="주문 등록 품절 상태" src="https://github.com/user-attachments/assets/3394e312-e7e9-4924-bddd-2b3f4abd1bb0" />

주문 등록 재고 부족
<img width="956" height="541" alt="주문 등록 재고 부족" src="https://github.com/user-attachments/assets/1f1bbb81-5a7d-4ccd-942b-96b5b12d4850" />

## 📒 To Reviewer

